### PR TITLE
feat: permanentid - replace sha256 by md5(30)+sha1(30)

### DIFF
--- a/src/main/java/com/coveo/pushapiclient/DocumentBuilder.java
+++ b/src/main/java/com/coveo/pushapiclient/DocumentBuilder.java
@@ -360,7 +360,9 @@ public class DocumentBuilder {
 
     private void generatePermanentId() {
         if (this.document.permanentId == null) {
-            this.document.permanentId = DigestUtils.sha256Hex(this.document.uri);
+            String md5 = DigestUtils.md5Hex(this.document.uri);
+            String sha1 = DigestUtils.sha1Hex(this.document.uri);
+            this.document.permanentId = md5.substring(0, 30) + sha1.substring(0, 30);
         }
     }
 }

--- a/src/test/java/com/coveo/pushapiclient/DocumentBuilderTest.java
+++ b/src/test/java/com/coveo/pushapiclient/DocumentBuilderTest.java
@@ -132,9 +132,11 @@ public class DocumentBuilderTest {
 
     @Test
     public void testWithPermanentIdGeneration() {
-        assertTrue(
+        docBuilder = new DocumentBuilder("https://foo.com", "bar");
+        assertEquals(
                 "permanentId should be generated automatically if not set",
-                docBuilder.marshalJsonObject().get("permanentId").getAsString().length() > 0
+                "aa2e0510b66edff7f05e2b30d4f1b3a4b5481c06b69f41751c54675c5afb",
+                docBuilder.marshalJsonObject().get("permanentId").getAsString()
         );
     }
 


### PR DESCRIPTION
The limit for `permanentid` in the index is actually 60 characters. hashlib.sha256() is generating a 64-character hash. 

Rather than simply truncating it, I am proposing the default algorithm to generate permanentid in the index: `md5[:30]+sha1[:30]`

----
[CDX-784](https://coveord.atlassian.net/browse/CDX-784)