### PR TITLE
chore: bump mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.11.2</version>
+            <version>4.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
To fix the following error when running tests on `PlatformClientTest.java`: 

```
java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
 at org.mockito.internal.configuration.plugins.PluginLoader$1.invoke(PluginLoader.java:84)
 at jdk.proxy2/jdk.proxy2.$Proxy16.isTypeMockable(Unknown Source)
 at org.mockito.internal.util.MockUtil.typeMockabilityOf(MockUtil.java:33)
 at org.mockito.internal.util.MockCreationValidator.validateType(MockCreationValidator.java:22)
 at org.mockito.internal.creation.MockSettingsImpl.validatedSettings(MockSettingsImpl.java:250)
 at org.mockito.internal.creation.MockSettingsImpl.build(MockSettingsImpl.java:232)
 at org.mockito.internal.MockitoCore.mock(MockitoCore.java:83)
 at org.mockito.Mockito.mock(Mockito.java:1954)
 at org.mockito.Mockito.mock(Mockito.java:1865)
 at com.coveo.pushapiclient.PlatformClientTest.setupClient(PlatformClientTest.java:105)
Caused by: java.lang.IllegalStateException: Internal problem occurred, please report it. Mockito is unable to load the default implementation of class that is a part of Mockito distribution. Failed to load interface org.mockito.plugins.MockMaker
 at org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.create(DefaultMockitoPlugins.java:91)
 at org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.getDefaultPlugin(DefaultMockitoPlugins.java:64)
 at org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:75)
 at org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:50)
 at org.mockito.internal.configuration.plugins.PluginRegistry.(PluginRegistry.java:26)
 at org.mockito.internal.configuration.plugins.Plugins.(Plugins.java:20)
 at org.mockito.internal.util.MockUtil.(MockUtil.java:28)
 ... 28 more
Caused by: java.lang.reflect.InvocationTargetException
 at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
 at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:483)
 at org.mockito.internal.configuration.plugins.DefaultMockitoPlugins.create(DefaultMockitoPlugins.java:89)
 ... 34 more
Caused by: java.lang.ExceptionInInitializerError
 at org.mockito.internal.exceptions.stacktrace.ConditionalStackTraceFilter.(ConditionalStackTraceFilter.java:16)
 at org.mockito.exceptions.base.MockitoException.filterStackTrace(MockitoException.java:41)
 at org.mockito.exceptions.base.MockitoException.(MockitoException.java:35)
 at org.mockito.internal.creation.bytebuddy.SubclassInjectionLoader.(SubclassInjectionLoader.java:36)
 at org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker.(SubclassByteBuddyMockMaker.java:33)
 at org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker.(ByteBuddyMockMaker.java:30)
 ... 37 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.mockito.internal.configuration.plugins.PluginRegistry.getStackTraceCleanerProvider()" because "org.mockito.internal.configuration.plugins.Plugins.registry" is null
 at org.mockito.internal.configuration.plugins.Plugins.getStackTraceCleanerProvider(Plugins.java:26)
 at org.mockito.internal.exceptions.stacktrace.StackTraceFilter.(StackTraceFilter.java:20)
 ... 44 more
```