### PR TITLE
RFC - Catalog source  2.0

### DIFF
--- a/src/main/java/com/coveo/pushapiclient/CatalogSource.java
+++ b/src/main/java/com/coveo/pushapiclient/CatalogSource.java
@@ -1,0 +1,17 @@
+package com.coveo.pushapiclient;
+
+public class CatalogSource {
+
+    public CatalogSource(String apiKey, String organizationId) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+    public DocumentUpdateService startDocumentUpdate(String string) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+    public FullCatalogUploadService startfullCatalogUpload(String string) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+}

--- a/src/main/java/com/coveo/pushapiclient/DocumentUpdateService.java
+++ b/src/main/java/com/coveo/pushapiclient/DocumentUpdateService.java
@@ -1,0 +1,20 @@
+package com.coveo.pushapiclient;
+
+public class DocumentUpdateService {
+
+    public DocumentUpdateService addOrUpdateDocument(DocumentBuilder document) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+    public DocumentUpdateService addOrUpdateDocument(PartialUpdateDocument document) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+    public DocumentUpdateService deleteDocument(DeleteDocument document) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+    public void flush() {
+    }
+
+}

--- a/src/main/java/com/coveo/pushapiclient/FullCatalogUploadService.java
+++ b/src/main/java/com/coveo/pushapiclient/FullCatalogUploadService.java
@@ -1,0 +1,13 @@
+package com.coveo.pushapiclient;
+
+public class FullCatalogUploadService {
+
+    public FullCatalogUploadService addDocument(DocumentBuilder document) {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+    public void flush() {
+        throw new java.lang.UnsupportedOperationException("TODO: To implement");
+    }
+
+}

--- a/src/main/java/com/coveo/pushapiclient/PartialUpdateDocument.java
+++ b/src/main/java/com/coveo/pushapiclient/PartialUpdateDocument.java
@@ -1,0 +1,5 @@
+package com.coveo.pushapiclient;
+
+public class PartialUpdateDocument {
+// TODO:
+}

--- a/src/main/java/com/coveo/pushapiclient/Sandbox.java
+++ b/src/main/java/com/coveo/pushapiclient/Sandbox.java
@@ -44,9 +44,6 @@ public class Sandbox {
     public static void streamBatch() {
         CatalogSource source = new CatalogSource("my_api_key", "my_org_id");
 
-        // Create a stream for pushing documents
-        // PushStream stream = source.getStream("source_id");
-
         // Prepare the push in "Stream" mode. In this mode, the push Service opens a
         // stream and creates the appropriates stream chunks
         FullCatalogUploadService service = source.startfullCatalogUpload("my_source_id");

--- a/src/main/java/com/coveo/pushapiclient/Sandbox.java
+++ b/src/main/java/com/coveo/pushapiclient/Sandbox.java
@@ -89,16 +89,3 @@ public class Sandbox {
     }
 
 }
-
-/**
- * Reasons of this approach
- * 1. Simply feed documentes to the service and prevent user from having to
- * store a list of documents before feeding them to the SDK... and avoid
- * java.lang.OutOfMemoryError errors.
- * 2. Both modes uses the same logic: 1. Create the appropriate service, feed
- * documents to the service, flush once finished feeding documents. The SDK
- * automatically handles batching.
- * 3. Create a disctinction between the 2 mode. Update and Stream mode. Each
- * mode has a dedicted service which only allow operations allowed by the
- * choosen mode. E.g. partial updates cannot be used in Stream mode.
- */

--- a/src/main/java/com/coveo/pushapiclient/Sandbox.java
+++ b/src/main/java/com/coveo/pushapiclient/Sandbox.java
@@ -1,0 +1,104 @@
+package com.coveo.pushapiclient;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class Sandbox {
+
+    /**
+     * Upload a document batch in push mode -> using the /files endpoint
+     */
+    public static void uploadBatch() {
+        CatalogSource source = new CatalogSource("my_api_key", "my_org_id");
+
+        // Prepare the push in "Update" mode. In this mode, the push Service will create
+        // S3 file containers with appropriate batches sizes.
+        DocumentUpdateService service = source.startDocumentUpdate("my_source_id");
+
+        // Create a stream for pushing documents
+
+        // Prepare a list of documents to add or update from an imaginary method
+        // The SDK handles the batching. Simply feed documents into the service
+        for (DocumentBuilder document : prepareDocuments()) {
+            service.addOrUpdateDocument(document);
+        }
+
+        // Prepare a list of documents to partially update from an imaginary method
+        // Same method can be used for both full and partial updates
+        for (PartialUpdateDocument document : preparePartialUpdateDocuments()) {
+            service.addOrUpdateDocument(document);
+        }
+
+        // Prepare a list of documents to delete from an imaginary method
+        for (DeleteDocument document : prepareDocumentsToDelete()) {
+            service.deleteDocument(document);
+        }
+
+        // Flush any previous documents buffered and not yet sent to the API.
+        service.flush();
+    }
+
+    /**
+     * Upload a document batch in stream mode -> using the /chunk endpoint
+     */
+    public static void streamBatch() {
+        CatalogSource source = new CatalogSource("my_api_key", "my_org_id");
+
+        // Create a stream for pushing documents
+        // PushStream stream = source.getStream("source_id");
+
+        // Prepare the push in "Stream" mode. In this mode, the push Service opens a
+        // stream and creates the appropriates stream chunks
+        FullCatalogUploadService service = source.startfullCatalogUpload("my_source_id");
+
+        // Prepare a list of documents to add from an imaginary method
+        // The SDK handles the batching.
+        for (DocumentBuilder document : prepareDocuments()) {
+            service.addDocument(document);
+        }
+        // Flush any previous documents buffered and not yet sent to the API.
+        // Closes the stream
+        service.flush();
+    }
+
+    /**
+     * Push and delete documents individually.
+     */
+    public static void pushSingleDocument() {
+        CatalogSource source = new CatalogSource("my_api_key", "my_org_id");
+        DocumentBuilder documentToAdd = new DocumentBuilder("https://my.document.uri", "My document title")
+                .withData("these words will be searchable")
+                .withAuthor("bob")
+                .withClickableUri("https://my.document.click.com")
+                .withFileExtension(".html")
+                .withMetadata(new HashMap<>() {
+                    {
+                        put("tags", new String[] { "the_first_tag", "the_second_tag" });
+                        put("version", 1);
+                        put("somekey", "somevalue");
+                    }
+                });
+
+        DeleteDocument documentToDelete = new DeleteDocument("https:/document.todelete.uri");
+
+        source.startDocumentUpdate("my_source_id")
+                .addOrUpdateDocument(documentToAdd)
+                .deleteDocument(documentToDelete)
+                .flush();
+
+    }
+
+}
+
+/**
+ * Reasons of this approach
+ * 1. Simply feed documentes to the service and prevent user from having to
+ * store a list of documents before feeding them to the SDK... and avoid
+ * java.lang.OutOfMemoryError errors.
+ * 2. Both modes uses the same logic: 1. Create the appropriate service, feed
+ * documents to the service, flush once finished feeding documents. The SDK
+ * automatically handles batching.
+ * 3. Create a disctinction between the 2 mode. Update and Stream mode. Each
+ * mode has a dedicted service which only allow operations allowed by the
+ * choosen mode. E.g. partial updates cannot be used in Stream mode.
+ */


### PR DESCRIPTION
Updated version from [Google Document](https://docs.google.com/document/d/1y8gm4UuVR2PiUT_btQloGnLnSKp-5sLtXCoirvsmtBs/edit).

## Motivation
1. Simply feed documents to the service and prevent user from having to store a list of documents before feeding them to the SDK... and avoid `java.lang.OutOfMemoryError` errors.
3. Both modes uses the same logic: 
    1. Instantiate the appropriate service 
    1. Feed documents to the service
    1. Flush buffered documents

Since the SDK automatically handles batching to remove this responsibility from the user, we need to know once the user is done pushing documents. 

4. Create a distinction between the 2 mode. `Update` and `Stream` mode. Each mode has a dedicated service which only exposes operations allowed by the chosen mode. E.g. Partial updates cannot while in `Stream` mode.

## Implementation Details
Here are the classes that will be publicly exposed.
### CatalogSource
A source 

### DocumentUpdateService
TODO:

### PartialUpdateDocument
TODO:

### FullCatalogUploadService
TODO:


Sample available in `src/main/java/com/coveo/pushapiclient/Sandbox.java`.