### PR TITLE
New Action Labels [DT-5906]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,4 +14,4 @@ jobs:
   analyze-java:
     uses: coveo/public-actions/.github/workflows/java-maven-openjdk11-codeql.yml@main
     with:
-      runs-on: "['linux', 'x64', 'ec2.instance-type = t3.large']"
+      runs-on: "['linux', 'x64', 'ec2 instance-type=t3.large']"


### PR DESCRIPTION
feat: use the new GitHub self-hosted action labels

https://coveord.atlassian.net/browse/DT-5906

Summary of changes:
  - the `self-hosted` label is renamed to `coveo`
  - the label options format changed
  - multiple options now **must** be concatenated into a single label

e.g.:

before: `runs-on: [ self-hosted, linux, x64, eks, eks.memory-limit = 8G, eks.cpu-request = 100m ]`
after: `runs-on: [ coveo, linux, x64, eks memory-limit=8G cpu-request=100m ]`

- See [DT-5543](https://coveord.atlassian.net/browse/DT-5543) for information about the core issue.
- Updated [documentation](https://coveord.atlassian.net/wiki/spaces/CM/pages/2863431752/Self-Hosted+Actions+Runners) for reference.
  
*You should merge this pull request yourself if you're OK with it. Feel free to comment if there's an issue!*


[DT-5543]: https://coveord.atlassian.net/browse/DT-5543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ