### PR TITLE
ci: fix typo in GH workflow

### DIFF
--- a/.github/workflows/pr-title-semantic-lint.yml
+++ b/.github/workflows/pr-title-semantic-lint.yml
@@ -1,11 +1,11 @@
 name: PrTitleSemanticLint
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, edited, synchronize, reopened]
 jobs:
   Lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:


### PR DESCRIPTION
Forgot to rename the `master` branch to `main`