### PR TITLE
ci: adjust script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@octokit/auth-app": "^4.0.9"
   },
   "scripts": {
-    "get-token": "node get-token.mjs"
+    "get-token": "node utils/get-token.mjs"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
A  typo that prevented the release script from running

Details: https://github.com/coveo/push-api-client.java/actions/runs/5247348743/jobs/9477387310