### PR TITLE
chore: put API requests into dedicated class

### DIFF
--- a/src/main/java/com/coveo/pushapiclient/ApiCore.java
+++ b/src/main/java/com/coveo/pushapiclient/ApiCore.java
@@ -1,0 +1,51 @@
+package com.coveo.pushapiclient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpResponse;
+
+// TODO: LENS-934 - Support throttling
+class ApiCore {
+  private final HttpClient httpClient;
+
+  public ApiCore() {
+    this.httpClient = HttpClient.newHttpClient();
+  }
+
+  public ApiCore(HttpClient httpClient) {
+    this.httpClient = httpClient;
+  }
+
+  public HttpResponse<String> post(URI uri, String[] headers)
+      throws IOException, InterruptedException {
+    return this.post(uri, headers, HttpRequest.BodyPublishers.ofString(""));
+  }
+
+  public HttpResponse<String> post(URI uri, String[] headers, BodyPublisher body)
+      throws IOException, InterruptedException {
+    HttpRequest request = HttpRequest.newBuilder().headers(headers).uri(uri).POST(body).build();
+    return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  public HttpResponse<String> put(URI uri, String[] headers, BodyPublisher body)
+      throws IOException, InterruptedException {
+    HttpRequest request = HttpRequest.newBuilder().headers(headers).uri(uri).PUT(body).build();
+    return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  public HttpResponse<String> delete(URI uri, String[] headers)
+      throws IOException, InterruptedException {
+    HttpRequest request = HttpRequest.newBuilder().headers(headers).uri(uri).DELETE().build();
+    return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  public HttpResponse<String> delete(URI uri, String[] headers, BodyPublisher body)
+      throws IOException, InterruptedException {
+    HttpRequest request =
+        HttpRequest.newBuilder().headers(headers).uri(uri).method("DELETE", body).build();
+    return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
## Simplify `PlatformClient` by removing code duplication 🥳
 ![image](https://github.com/coveo/push-api-client.java/assets/12199712/346121d6-a960-404f-9b4a-e357c6185414)

## Prepare groundwork to [handle throttling](https://coveord.atlassian.net/browse/LENS-934).
Create an `ApiCore` class to handle all API requests

_p.s._
> I need a PR to trigger the release GitHub action since it did not work last time. The release failed because previous versions (`v.2.1.0` and `v2.2.0`) were not tagged. Therefore, the [release action](https://github.com/google-github-actions/release-please-action) did not bump the `pom.xml` version to the right one.
