### PR TITLE
docs: use appropriate javadoc url syntax

### DIFF
--- a/src/main/java/com/coveo/pushapiclient/ApiUrl.java
+++ b/src/main/java/com/coveo/pushapiclient/ApiUrl.java
@@ -10,8 +10,10 @@ import java.util.regex.Pattern;
 
 /**
  * Private util class to extract dynamic parts from a API URL Handles extraction of identifiers and
- * platform URL from a source URL. @See https://docs.coveo.com/en/1546#push-api-url
- * https://docs.coveo.com/en/3295#stream-api-url
+ * platform URL from a source URL.
+ *
+ * @see <a href="https://docs.coveo.com/en/1546#push-api-url">Push API url</a>
+ * @see <a href="https://docs.coveo.com/en/3295#stream-api-url">Stream API url</a>
  */
 class ApiUrl {
   private final String organizationId;

--- a/src/main/java/com/coveo/pushapiclient/BatchIdentity.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchIdentity.java
@@ -4,7 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.util.List;
 
-/** See [Manage Batches of Security Identities](https://docs.coveo.com/en/55) */
+/**
+ * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
+ */
 public class BatchIdentity {
 
   private List<SecurityIdentityModel> members;

--- a/src/main/java/com/coveo/pushapiclient/BatchIdentityRecord.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchIdentityRecord.java
@@ -2,7 +2,9 @@ package com.coveo.pushapiclient;
 
 import com.google.gson.JsonObject;
 
-/** See [BatchIdentityBody](https://docs.coveo.com/en/139#batchidentitybody) */
+/**
+ * @see <a href="https://docs.coveo.com/en/139#batchidentitybody">BatchIdentityBody]</a>
+ */
 public class BatchIdentityRecord {
 
   private JsonObject[] members;

--- a/src/main/java/com/coveo/pushapiclient/BatchUpdate.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchUpdate.java
@@ -4,7 +4,9 @@ import com.google.gson.JsonObject;
 import java.util.List;
 import java.util.Objects;
 
-/** See [Manage Batches of Items in a Push Source](https://docs.coveo.com/en/90) */
+/**
+ * @see <a href="https://docs.coveo.com/en/90">Manage Batches of Items in a Push Source</a>
+ */
 public class BatchUpdate {
 
   private final List<DocumentBuilder> addOrUpdate;

--- a/src/main/java/com/coveo/pushapiclient/BatchUpdateRecord.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchUpdateRecord.java
@@ -3,7 +3,9 @@ package com.coveo.pushapiclient;
 import com.google.gson.JsonObject;
 import java.util.Arrays;
 
-/** See [BatchDocumentBody](https://docs.coveo.com/en/75/#batchdocumentbody) */
+/**
+ * @see <a href="https://docs.coveo.com/en/75/#batchdocumentbody">BatchDocumentBody</a>
+ */
 public class BatchUpdateRecord {
 
   private final JsonObject[] addOrUpdate;

--- a/src/main/java/com/coveo/pushapiclient/CatalogSource.java
+++ b/src/main/java/com/coveo/pushapiclient/CatalogSource.java
@@ -15,7 +15,8 @@ public class CatalogSource implements StreamEnabledSource {
    * @param platformClient
    * @param name The name of the source to create
    * @param sourceVisibility The security option that should be applied to the content of the
-   *     source. See [Content Security](https://docs.coveo.com/en/1779).
+   *     source.
+   * @see <a href="https://docs.coveo.com/en/1779">Content Security</a>
    * @return
    * @throws IOException
    * @throws InterruptedException

--- a/src/main/java/com/coveo/pushapiclient/DocumentBuilder.java
+++ b/src/main/java/com/coveo/pushapiclient/DocumentBuilder.java
@@ -29,8 +29,10 @@ public class DocumentBuilder {
   private final Document document;
 
   /**
-   * @param uri the URI of the document. See {@link Document#uri}
-   * @param title the title of the document. See {@link Document#title}
+   * @param uri the URI of the document.
+   * @see {@link Document#uri}
+   * @param title the title of the document.
+   * @see {@link Document#title}
    */
   public DocumentBuilder(String uri, String title) {
     this.document = new Document();
@@ -43,8 +45,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the data of the document. See {@link Document#data}
+   * Set the data of the document.
    *
+   * @see {@link Document#data}
    * @param data
    * @return
    */
@@ -54,8 +57,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the date of the document. See {@link Document#date}
+   * Set the date of the document.
    *
+   * @see {@link Document#date}
    * @param date
    * @return
    */
@@ -66,8 +70,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the date of the document. See {@link Document#date}
+   * Set the date of the document.
    *
+   * @see {@link Document#date}
    * @param date
    * @return
    */
@@ -78,8 +83,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the date of the document. See {@link Document#date}
+   * Set the date of the document.
    *
+   * @see {@link Document#date}
    * @param date
    * @return
    */
@@ -90,8 +96,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the date of the document. See {@link Document#date}
+   * Set the date of the document.
    *
+   * @see {@link Document#date}
    * @param date
    * @return
    */
@@ -101,8 +108,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the modified date of the document. See {@link Document#modifiedDate}
+   * Set the modified date of the document.
    *
+   * @see {@link Document#modifiedDate}
    * @param date
    * @return
    */
@@ -113,8 +121,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the modified date of the document. See {@link Document#modifiedDate}
+   * Set the modified date of the document.
    *
+   * @see {@link Document#modifiedDate}
    * @param date
    * @return
    */
@@ -125,8 +134,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the modified date of the document. See {@link Document#modifiedDate}
+   * Set the modified date of the document.
    *
+   * @see {@link Document#modifiedDate}
    * @param date
    * @return
    */
@@ -136,8 +146,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the modified date of the document. See {@link Document#modifiedDate}
+   * Set the modified date of the document.
    *
+   * @see {@link Document#modifiedDate}
    * @param date
    * @return
    */
@@ -148,8 +159,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the permanentID of the document. See {@link Document#permanentId}
+   * Set the permanentID of the document.
    *
+   * @see {@link Document#permanentId}
    * @param permanentId
    * @return
    */
@@ -159,9 +171,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the base64 encoded, compressed binary data of the document. See {@link
-   * Document#compressedBinaryData}
+   * Set the base64 encoded, compressed binary data of the document.
    *
+   * @see {@link Document#compressedBinaryData}
    * @param compressedBinaryData
    * @return
    */
@@ -171,9 +183,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the file container file ID for the compressed binary data of the document. See {@link
-   * Document#compressedBinaryDataFileId}
+   * Set the file container file ID for the compressed binary data of the document.
    *
+   * @see {@link Document#compressedBinaryDataFileId}
    * @param compressedBinaryDataFileId
    * @return
    */
@@ -183,8 +195,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the file extension on the document. See {@link Document#fileExtension}
+   * Set the file extension on the document.
    *
+   * @see {@link Document#fileExtension}
    * @param fileExtension
    * @return
    */
@@ -195,8 +208,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the parentID on the document. See {@link Document#parentId}
+   * Set the parentID on the document.
    *
+   * @see {@link Document#parentId}
    * @param parentID
    * @return
    */
@@ -206,8 +220,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the clickableURI on the document. See {@link Document#clickableUri}
+   * Set the clickableURI on the document.
    *
+   * @see {@link Document#clickableUri}
    * @param clickableUri
    * @return
    */
@@ -217,8 +232,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the author on the document. See {@link Document#author}
+   * Set the author on the document.
    *
+   * @see {@link Document#author}
    * @param author
    * @return
    */
@@ -228,8 +244,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Add a single metadata key and value pair on the document. See {@link Document#metadata}
+   * Add a single metadata key and value pair on the document.
    *
+   * @see {@link Document#metadata}
    * @param key
    * @param metadataValue
    * @return
@@ -240,8 +257,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Add a single metadata key and value pair on the document. See {@link Document#metadata}
+   * Add a single metadata key and value pair on the document.
    *
+   * @see {@link Document#metadata}
    * @param key
    * @param metadataValue
    * @return
@@ -252,8 +270,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Add a single metadata key and value pair on the document. See {@link Document#metadata}
+   * Add a single metadata key and value pair on the document.
    *
+   * @see {@link Document#metadata}
    * @param key
    * @param metadataValue
    * @return
@@ -264,8 +283,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Add a single metadata key and value pair on the document. See {@link Document#metadata}
+   * Add a single metadata key and value pair on the document.
    *
+   * @see {@link Document#metadata}
    * @param key
    * @param metadataValue
    * @return
@@ -276,8 +296,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set metadata on the document. See {@link Document#metadata}
+   * Set metadata on the document.
    *
+   * @see {@link Document#metadata}
    * @param metadata
    * @return
    */
@@ -287,8 +308,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set allowed identities on the document. See {@link Document#permissions}
+   * Set allowed identities on the document.
    *
+   * @see {@link Document#permissions}
    * @param allowedPermissions
    * @return
    */
@@ -298,8 +320,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set denied identities on the document. See {@link Document#permissions}
+   * Set denied identities on the document.
    *
+   * @see {@link Document#permissions}
    * @param deniedPermissions
    * @return
    */
@@ -309,8 +332,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set allowAnonymous for permissions on the document. See {@link Document#permissions}
+   * Set allowAnonymous for permissions on the document.
    *
+   * @see {@link Document#permissions}
    * @param allowAnonymous
    * @return
    */
@@ -320,8 +344,9 @@ public class DocumentBuilder {
   }
 
   /**
-   * Set the fully built out DocumentPermissions array. See {@Link Document#permissions}
+   * Set the fully built out DocumentPermissions array.
    *
+   * @see {@Link Document#permissions}
    * @param documentPermissions
    * @return
    */
@@ -383,7 +408,8 @@ public class DocumentBuilder {
     if (reservedKeynames.contains(key)) {
       throw new RuntimeException(
           String.format(
-              "Cannot use %s as a metadata key: It is a reserved keynames. See https://docs.coveo.com/en/78/index-content/push-api-reference#json-document-reserved-key-names",
+              "Cannot use %s as a metadata key: It is a reserved keynames. See"
+                  + " https://docs.coveo.com/en/78/index-content/push-api-reference#json-document-reserved-key-names",
               key));
     }
   }

--- a/src/main/java/com/coveo/pushapiclient/FileContainer.java
+++ b/src/main/java/com/coveo/pushapiclient/FileContainer.java
@@ -2,7 +2,9 @@ package com.coveo.pushapiclient;
 
 import java.util.Map;
 
-/** See [Creating a FileContainer](https://docs.coveo.com/en/43) */
+/**
+ * @see <a href="https://docs.coveo.com/en/43">Creating a FileContainer</a>
+ */
 public class FileContainer {
   public String uploadUri;
   public String fileId;

--- a/src/main/java/com/coveo/pushapiclient/PlatformClient.java
+++ b/src/main/java/com/coveo/pushapiclient/PlatformClient.java
@@ -22,7 +22,8 @@ public class PlatformClient {
    * Construct a PlatformClient
    *
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>
    * @param organizationId The Coveo Organization identifier.
    */
   public PlatformClient(String apiKey, String organizationId) {
@@ -33,7 +34,8 @@ public class PlatformClient {
    * Construct a PlatformClient
    *
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>
    * @param organizationId The Coveo Organization identifier.
    * @param platformUrl The PlatformUrl.
    */
@@ -48,7 +50,8 @@ public class PlatformClient {
    * Construct a PlatformClient
    *
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>
    * @param organizationId The Coveo Organization identifier.
    * @param httpClient The HttpClient.
    */
@@ -63,7 +66,8 @@ public class PlatformClient {
    * @deprecated Please now use PlatformUrl to define your Platform environment
    * @see PlatformUrl Construct a PlatformUrl
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>
    * @param organizationId The Coveo Organization identifier.
    * @param environment The Environment to be used.
    */
@@ -98,7 +102,8 @@ public class PlatformClient {
    * @param name The name of the source to create
    * @param sourceType The type of the source to create
    * @param sourceVisibility The security option that should be applied to the content of the
-   *     source. See [Content Security](https://docs.coveo.com/en/1779).
+   *     source.
+   * @see <a href="https://docs.coveo.com/en/1779">Content Security</a>
    * @return
    * @throws IOException
    * @throws InterruptedException
@@ -132,10 +137,10 @@ public class PlatformClient {
   }
 
   /**
-   * Create or update a security identity. See [Adding a Single Security
-   * Identity](https://docs.coveo.com/en/167) and [Security Identity
-   * Models](https://docs.coveo.com/en/139).
+   * Create or update a security identity.
    *
+   * @see <a href="https://docs.coveo.com/en/167">Adding a Single Security Identity</a>
+   * @see <a href="https://docs.coveo.com/en/139">Security Identity Models</a>.
    * @param securityProviderId
    * @param securityIdentityModel
    * @return
@@ -162,10 +167,10 @@ public class PlatformClient {
   }
 
   /**
-   * Create or update a security identity alias. See [Adding a Single
-   * Alias](https://docs.coveo.com/en/142) and [User Alias Definition
-   * Examples](https://docs.coveo.com/en/46).
+   * Create or update a security identity alias.
    *
+   * @see <a href="https://docs.coveo.com/en/142">Adding a Single Alias</a>
+   * @see <a href="https://docs.coveo.com/en/46">User Alias Definition Examples</a>
    * @param securityProviderId
    * @param securityIdentityAlias
    * @return
@@ -192,9 +197,9 @@ public class PlatformClient {
   }
 
   /**
-   * Delete a security identity. See [Disabling a Single Security
-   * Identity](https://docs.coveo.com/en/84).
+   * Delete a security identity.
    *
+   * @see <a href="https://docs.coveo.com/en/84">Disabling a Single Security Identity</a>
    * @param securityProviderId
    * @param securityIdentityToDelete
    * @return
@@ -221,9 +226,9 @@ public class PlatformClient {
   }
 
   /**
-   * Delete old security identities. See [Disabling Old Security
-   * Identities](https://docs.coveo.com/en/33).
+   * Delete old security identities.
    *
+   * @see <a href="https://docs.coveo.com/en/33">Disabling Old Security Identities</a>
    * @param securityProviderId
    * @param batchDelete
    * @return
@@ -261,9 +266,9 @@ public class PlatformClient {
   }
 
   /**
-   * Manage batches of security identities. See [Manage Batches of Security
-   * Identities](https://docs.coveo.com/en/55).
+   * Manage batches of security identities.
    *
+   * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
    * @param securityProviderId
    * @param batchConfig
    * @return
@@ -293,9 +298,9 @@ public class PlatformClient {
   }
 
   /**
-   * Adds or updates an individual item in a push source. See [Adding a Single Item in a Push
-   * Source](https://docs.coveo.com/en/133).
+   * Adds or updates an individual item in a push source.
    *
+   * @see <a href="https://docs.coveo.com/en/133">Adding a Single Item in a Push Source</a>
    * @param sourceId
    * @param documentJSON
    * @param documentId
@@ -328,8 +333,9 @@ public class PlatformClient {
 
   /**
    * Deletes a specific item from a Push source. Optionally, the child items of that item can also
-   * be deleted. See [Deleting an Item in a Push Source](https://docs.coveo.com/en/171).
+   * be deleted.
    *
+   * @see <a href="https://docs.coveo.com/en/171">Deleting an Item in a Push Source</a>
    * @param sourceId
    * @param documentId
    * @param deleteChildren
@@ -411,8 +417,9 @@ public class PlatformClient {
   }
 
   /**
-   * Create a file container. See [Creating a File Container](https://docs.coveo.com/en/43).
+   * Create a file container.
    *
+   * @see <a href="https://docs.coveo.com/en/43">Creating a File Container</a>
    * @return
    * @throws IOException
    * @throws InterruptedException
@@ -433,9 +440,9 @@ public class PlatformClient {
   }
 
   /**
-   * Update the status of a Push source. See [Updating the Status of a Push
-   * Source](https://docs.coveo.com/en/35).
+   * Update the status of a Push source.
    *
+   * @see <a href="https://docs.coveo.com/en/35">Updating the Status of a Push Source</a>
    * @param status
    * @return
    * @throws IOException
@@ -461,9 +468,11 @@ public class PlatformClient {
   }
 
   /**
-   * Upload content update into a file container. See [Upload the Content Update into the File
-   * Container](https://docs.coveo.com/en/90/index-content/manage-batches-of-items-in-a-push-source#step-2-upload-the-content-update-into-the-file-container).
+   * Upload content update into a file container.
    *
+   * @see <a
+   *     href="https://docs.coveo.com/en/90/index-content/manage-batches-of-items-in-a-push-source#step-2-upload-the-content-update-into-the-file-container">Upload
+   *     the Content Update into the File Container</a>
    * @param fileContainer
    * @param batchUpdateJson
    * @return
@@ -490,9 +499,11 @@ public class PlatformClient {
   }
 
   /**
-   * Push a file container into a push source. See [Push the File Container into a Push
-   * Source](https://docs.coveo.com/en/90/index-content/manage-batches-of-items-in-a-push-source#step-3-push-the-file-container-into-a-push-source).
+   * Push a file container into a push source.
    *
+   * @see <a
+   *     href="https://docs.coveo.com/en/90/index-content/manage-batches-of-items-in-a-push-source#step-3-push-the-file-container-into-a-push-source">Push
+   *     the File Container into a Push Source</a>
    * @param sourceId
    * @param fileContainer
    * @return
@@ -520,9 +531,11 @@ public class PlatformClient {
   }
 
   /**
-   * Push a binary to a File Container. See [Upload the Item Data Into the File
-   * Container](https://docs.coveo.com/en/69#step-2-upload-the-item-data-into-the-file-container)
+   * Push a binary to a File Container.
    *
+   * @see <a
+   *     href="https://docs.coveo.com/en/69#step-2-upload-the-item-data-into-the-file-container">Upload
+   *     the Item Data Into the File Container</a>
    * @param fileContainer
    * @param fileAsBytes
    * @return

--- a/src/main/java/com/coveo/pushapiclient/PlatformUrl.java
+++ b/src/main/java/com/coveo/pushapiclient/PlatformUrl.java
@@ -11,7 +11,7 @@ public class PlatformUrl {
   /**
    * @param environment The environment platform of your organization
    * @param region The physical center of your organization
-   * @see https://docs.coveo.com/en/2976
+   * @see <a href="https://docs.coveo.com/en/2976">Deployment regions and strategies</a>
    */
   public PlatformUrl(Environment environment, Region region) {
     this.environment = environment;

--- a/src/main/java/com/coveo/pushapiclient/PushAPIStatus.java
+++ b/src/main/java/com/coveo/pushapiclient/PushAPIStatus.java
@@ -1,8 +1,9 @@
 package com.coveo.pushapiclient;
 
 /**
- * Enum for possible PushAPI statuses. See [Updating the Status of a Push
- * Source](https://docs.coveo.com/en/35).
+ * Enum for possible PushAPI statuses.
+ *
+ * @see <a href="https://docs.coveo.com/en/35">Updating the Status of a Push Source</a>
  */
 public enum PushAPIStatus {
   IDLE,

--- a/src/main/java/com/coveo/pushapiclient/PushSource.java
+++ b/src/main/java/com/coveo/pushapiclient/PushSource.java
@@ -39,7 +39,8 @@ public class PushSource implements PushEnabledSource {
    * @param name
    * @param name The name of the source to create
    * @param sourceVisibility The security option that should be applied to the content of the
-   *     source. See [Content Security](https://docs.coveo.com/en/1779).
+   *     source.
+   * @see <a href="https://docs.coveo.com/en/1779">Content Security</a>
    * @return
    * @throws IOException
    * @throws InterruptedException
@@ -132,10 +133,10 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Create or update a security identity. See [Adding a Single Security
-   * Identity](https://docs.coveo.com/en/167) and [Security Identity
-   * Models](https://docs.coveo.com/en/139).
+   * Create or update a security identity.
    *
+   * @see <a href="https://docs.coveo.com/en/167">Adding a Single Security Identity</a>
+   * @see <a href="https://docs.coveo.com/en/139">Security Identity Models</a>
    * @param securityProviderId
    * @param securityIdentityModel
    * @return
@@ -150,10 +151,10 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Create or update a security identity alias. See [Adding a Single
-   * Alias](https://docs.coveo.com/en/142) and [User Alias Definition
-   * Examples](https://docs.coveo.com/en/46).
+   * Create or update a security identity alias.
    *
+   * @see <a href="https://docs.coveo.com/en/142">Adding a Single Alias</a>
+   * @see <a href="https://docs.coveo.com/en/46">User Alias Definition Examples</a>
    * @param securityProviderId
    * @param securityIdentityAliasModel
    * @return
@@ -168,9 +169,9 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Delete a security identity. See [Disabling a Single Security
-   * Identity](https://docs.coveo.com/en/84).
+   * Delete a security identity.
    *
+   * @see <a href="https://docs.coveo.com/en/84">Disabling a Single Security Identity</a>
    * @param securityProviderId
    * @param securityIdentityDelete
    * @return
@@ -184,9 +185,9 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Update the status of a Push source. See [Updating the Status of a Push
-   * Source](https://docs.coveo.com/en/35).
+   * Update the status of a Push source.
    *
+   * @see <a href="https://docs.coveo.com/en/35">Updating the Status of a Push Source</a>
    * @param status
    * @return
    * @throws IOException
@@ -198,9 +199,9 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Delete old security identities. See [Disabling Old Security
-   * Identities](https://docs.coveo.com/en/33).
+   * Delete old security identities.
    *
+   * @see <a href="https://docs.coveo.com/en/33">Disabling Old Security Identities</a>
    * @param securityProviderId
    * @param batchDelete
    * @return
@@ -214,9 +215,9 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Manage batches of security identities. See [Manage Batches of Security
-   * Identities](https://docs.coveo.com/en/55).
+   * Manage batches of security identities.
    *
+   * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
    * @param securityProviderId
    * @param batchConfig
    * @return
@@ -230,9 +231,9 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Manages pushing batches of Security Identities to a File Container, then into Coveo. See
-   * [Manage Batches of Security Identities](https://docs.coveo.com/en/55)
+   * Manages pushing batches of Security Identities to a File Container, then into Coveo.
    *
+   * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
    * @param securityProviderId
    * @param batchIdentity
    * @return
@@ -260,9 +261,9 @@ public class PushSource implements PushEnabledSource {
   }
 
   /**
-   * Adds or updates an individual item in a push source. See [Adding a Single Item in a Push
-   * Source](https://docs.coveo.com/en/133).
+   * Adds or updates an individual item in a push source.
    *
+   * @see <a href="https://docs.coveo.com/en/133">Adding a Single Item in a Push Source</a>
    * @param docBuilder
    * @return
    * @throws IOException
@@ -280,8 +281,9 @@ public class PushSource implements PushEnabledSource {
 
   /**
    * Deletes a specific item from a Push source. Optionally, the child items of that item can also
-   * be deleted. See [Deleting an Item in a Push Source](https://docs.coveo.com/en/171).
+   * be deleted.
    *
+   * @see <a href="https://docs.coveo.com/en/171">Deleting an Item in a Push Source</a>
    * @param documentId
    * @param deleteChildren
    * @return

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityAliasModel.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityAliasModel.java
@@ -1,6 +1,8 @@
 package com.coveo.pushapiclient;
 
-/** See [User Alias Definition Examples](https://docs.coveo.com/en/46). */
+/**
+ * @see <a href="https://docs.coveo.com/en/46">User Alias Definition Examples</a>
+ */
 public class SecurityIdentityAliasModel extends SecurityIdentityModelBase {
   public final AliasMapping[] mappings;
 

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityBatchConfig.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityBatchConfig.java
@@ -2,7 +2,9 @@ package com.coveo.pushapiclient;
 
 import java.util.Objects;
 
-/** See [Manage Batches of Security Identities](https://docs.coveo.com/en/55). */
+/**
+ * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
+ */
 public class SecurityIdentityBatchConfig {
 
   private final String fileId;

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityBatchResponse.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityBatchResponse.java
@@ -3,8 +3,9 @@ package com.coveo.pushapiclient;
 import java.net.http.HttpResponse;
 
 /**
- * Used for the responses when pushing batches of Security Identities. See [Manage Batches of
- * Security Identities](https://docs.coveo.com/en/55)
+ * Used for the responses when pushing batches of Security Identities.
+ *
+ * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
  */
 public class SecurityIdentityBatchResponse {
 

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityDelete.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityDelete.java
@@ -2,7 +2,9 @@ package com.coveo.pushapiclient;
 
 import java.util.Objects;
 
-/** See [Disabling a Single Security Identity](https://docs.coveo.com/en/84) */
+/**
+ * @see <a href="https://docs.coveo.com/en/84">Disabling a Single Security Identity</a>
+ */
 public class SecurityIdentityDelete {
 
   private final IdentityModel identity;

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityDeleteOptions.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityDeleteOptions.java
@@ -2,7 +2,9 @@ package com.coveo.pushapiclient;
 
 import java.util.Objects;
 
-/** See [Disabling Old Security Identities](https://docs.coveo.com/en/33) */
+/**
+ * @see <a href="https://docs.coveo.com/en/33">Disabling Old Security Identities</a>
+ */
 public class SecurityIdentityDeleteOptions {
 
   private final Integer queueDelay;

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityModel.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityModel.java
@@ -1,6 +1,8 @@
 package com.coveo.pushapiclient;
 
-/** See [Security Identity Models](https://docs.coveo.com/en/139) */
+/**
+ * @see <a href="https://docs.coveo.com/en/139">Security Identity Models</a>
+ */
 public class SecurityIdentityModel extends SecurityIdentityModelBase {
   public final IdentityModel[] members;
 

--- a/src/main/java/com/coveo/pushapiclient/Source.java
+++ b/src/main/java/com/coveo/pushapiclient/Source.java
@@ -10,7 +10,8 @@ public class Source {
 
   /**
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>.
    * @param organizationId The Coveo Organization identifier.
    */
   public Source(String apiKey, String organizationId) {
@@ -19,7 +20,8 @@ public class Source {
 
   /**
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>.
    * @param organizationId The Coveo Organization identifier.
    * @param platformUrl
    */
@@ -31,7 +33,8 @@ public class Source {
    * @deprecated Please now use PlatformUrl to define your Platform environment
    * @see PlatformUrl Construct a PlatformUrl
    * @param apiKey An apiKey capable of pushing documents and managing sources in a Coveo
-   *     organization. See [Manage API Keys](https://docs.coveo.com/en/1718).
+   *     organization.
+   * @see <a href="https://docs.coveo.com/en/1718">Manage API Keys</a>.
    * @param organizationId The Coveo Organization identifier.
    * @param environment The Environment to be used.
    */
@@ -45,7 +48,8 @@ public class Source {
    *
    * @param name The name of the source to create
    * @param sourceVisibility The security option that should be applied to the content of the
-   *     source. See [Content Security](https://docs.coveo.com/en/1779).
+   *     source.
+   * @see <a href="https://docs.coveo.com/en/1779">Content Security</a>
    * @return
    * @throws IOException
    * @throws InterruptedException
@@ -56,10 +60,10 @@ public class Source {
   }
 
   /**
-   * Create or update a security identity. See [Adding a Single Security
-   * Identity](https://docs.coveo.com/en/167) and [Security Identity
-   * Models](https://docs.coveo.com/en/139).
+   * Create or update a security identity.
    *
+   * @see <a href="https://docs.coveo.com/en/167">Adding a Single Security Identity</a>
+   * @see <a href="https://docs.coveo.com/en/139">Security Identity Models</a>
    * @param securityProviderId
    * @param securityIdentityModel
    * @return
@@ -74,10 +78,10 @@ public class Source {
   }
 
   /**
-   * Create or update a security identity alias. See [Adding a Single
-   * Alias](https://docs.coveo.com/en/142) and [User Alias Definition
-   * Examples](https://docs.coveo.com/en/46).
+   * Create or update a security identity alias.
    *
+   * @see <a href="https://docs.coveo.com/en/142">Adding a Single Alias</a>
+   * @see <a href="https://docs.coveo.com/en/46">User Alias Definition Examples</a>
    * @param securityProviderId
    * @param securityIdentityAliasModel
    * @return
@@ -92,9 +96,9 @@ public class Source {
   }
 
   /**
-   * Delete a security identity. See [Disabling a Single Security
-   * Identity](https://docs.coveo.com/en/84).
+   * Delete a security identity.
    *
+   * @see <a href="https://docs.coveo.com/en/84">Disabling a Single Security Identity</a>
    * @param securityProviderId
    * @param securityIdentityDelete
    * @return
@@ -108,9 +112,9 @@ public class Source {
   }
 
   /**
-   * Update the status of a Push source. See [Updating the Status of a Push
-   * Source](https://docs.coveo.com/en/35).
+   * Update the status of a Push source.
    *
+   * @see <a href="https://docs.coveo.com/en/35">Updating the Status of a Push Source</a>
    * @param sourceId
    * @param status
    * @return
@@ -123,9 +127,9 @@ public class Source {
   }
 
   /**
-   * Delete old security identities. See [Disabling Old Security
-   * Identities](https://docs.coveo.com/en/33).
+   * Delete old security identities.
    *
+   * @see <a href="https://docs.coveo.com/en/33">Disabling Old Security Identities</a>
    * @param securityProviderId
    * @param batchDelete
    * @return
@@ -139,9 +143,9 @@ public class Source {
   }
 
   /**
-   * Manage batches of security identities. See [Manage Batches of Security
-   * Identities](https://docs.coveo.com/en/55).
+   * Manage batches of security identities.
    *
+   * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
    * @param securityProviderId
    * @param batchConfig
    * @return
@@ -155,9 +159,9 @@ public class Source {
   }
 
   /**
-   * Adds or updates an individual item in a push source. See [Adding a Single Item in a Push
-   * Source](https://docs.coveo.com/en/133).
+   * Adds or updates an individual item in a push source.
    *
+   * @see <a href="https://docs.coveo.com/en/133">Adding a Single Item in a Push Source</a>
    * @param sourceId
    * @param docBuilder
    * @return
@@ -176,8 +180,9 @@ public class Source {
 
   /**
    * Deletes a specific item from a Push source. Optionally, the child items of that item can also
-   * be deleted. See [Deleting an Item in a Push Source](https://docs.coveo.com/en/171).
+   * be deleted.
    *
+   * @see <a href="https://docs.coveo.com/en/171">Deleting an Item in a Push Source</a>
    * @param sourceId
    * @param documentId
    * @param deleteChildren
@@ -192,9 +197,9 @@ public class Source {
   }
 
   /**
-   * Manage batches of items in a push source. See [Manage Batches of Items in a Push
-   * Source](https://docs.coveo.com/en/90)
+   * Manage batches of items in a push source.
    *
+   * @see <a href="https://docs.coveo.com/en/90">Manage Batches of Items in a Push Source</a>
    * @param sourceId
    * @param batchUpdate
    * @return
@@ -211,9 +216,9 @@ public class Source {
   }
 
   /**
-   * Manages pushing batches of Security Identities to a File Container, then into Coveo. See
-   * [Manage Batches of Security Identities](https://docs.coveo.com/en/55)
+   * Manages pushing batches of Security Identities to a File Container, then into Coveo.
    *
+   * @see <a href="https://docs.coveo.com/en/55">Manage Batches of Security Identities</a>
    * @param securityProviderId
    * @param batchIdentity
    * @return
@@ -241,8 +246,9 @@ public class Source {
   }
 
   /**
-   * Creates a File Container. [Creating a File Container](https://docs.coveo.com/en/43)
+   * Creates a File Container.
    *
+   * @see <a href="https://docs.coveo.com/en/43">Creating a File Container</a>
    * @return
    * @throws IOException
    * @throws InterruptedException
@@ -253,9 +259,9 @@ public class Source {
   }
 
   /**
-   * Push file to a File Container. [Using the compressedBinaryDataFileId
-   * Property](https://docs.coveo.com/en/69)
+   * Push file to a File Container.
    *
+   * @see <a href="https://docs.coveo.com/en/69">Using the compressedBinaryDataFileId Property</a>
    * @param fileContainer
    * @param fileAsBytes
    * @return

--- a/src/main/java/com/coveo/pushapiclient/SourceVisibility.java
+++ b/src/main/java/com/coveo/pushapiclient/SourceVisibility.java
@@ -2,7 +2,7 @@ package com.coveo.pushapiclient;
 
 /**
  * SourceVisibility controls the content security option that should be applied to the items in a
- * source. See https://docs.coveo.com/en/1779/index-content/content-security
+ * source. <a href="https://docs.coveo.com/en/1779/">Content Security</a>
  */
 public enum SourceVisibility {
   /** Items can be accessed by the source owner only. */


### PR DESCRIPTION
Use javadoc syntax as explained in the [Javadoc Reference Guide](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see).