### PR TITLE
fix(LENS-1799): logging improvements

### DIFF
--- a/src/main/java/com/coveo/pushapiclient/DocumentUploadQueue.java
+++ b/src/main/java/com/coveo/pushapiclient/DocumentUploadQueue.java
@@ -64,7 +64,9 @@ class DocumentUploadQueue {
       this.flush();
     }
     documentToAddList.add(document);
-    logger.info("Adding document to batch: " + document.getDocument().uri);
+    if (logger.isDebugEnabled()) {
+      logger.info("Adding document to batch: " + document.getDocument().uri);
+    }
     this.size += sizeOfDoc;
   }
 
@@ -86,7 +88,9 @@ class DocumentUploadQueue {
       this.flush();
     }
     documentToDeleteList.add(document);
-    logger.info("Adding document to batch: " + document.documentId);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Adding document to batch: " + document.documentId);
+    }
     this.size += sizeOfDoc;
   }
 

--- a/src/main/java/com/coveo/pushapiclient/DocumentUploadQueue.java
+++ b/src/main/java/com/coveo/pushapiclient/DocumentUploadQueue.java
@@ -65,7 +65,7 @@ class DocumentUploadQueue {
     }
     documentToAddList.add(document);
     if (logger.isDebugEnabled()) {
-      logger.info("Adding document to batch: " + document.getDocument().uri);
+      logger.debug("Adding document to batch: " + document.getDocument().uri);
     }
     this.size += sizeOfDoc;
   }

--- a/src/main/java/com/coveo/pushapiclient/StreamDocumentUploadQueue.java
+++ b/src/main/java/com/coveo/pushapiclient/StreamDocumentUploadQueue.java
@@ -56,7 +56,9 @@ public class StreamDocumentUploadQueue extends DocumentUploadQueue {
       this.flush();
     }
     documentToPartiallyUpdateList.add(document);
-    logger.info("Adding document to batch: " + document.documentId);
+    if (logger.isDebugEnabled()) {
+      logger.info("Adding document to batch: " + document.documentId);
+    }
     this.size += sizeOfDoc;
   }
 

--- a/src/main/java/com/coveo/pushapiclient/StreamDocumentUploadQueue.java
+++ b/src/main/java/com/coveo/pushapiclient/StreamDocumentUploadQueue.java
@@ -57,7 +57,7 @@ public class StreamDocumentUploadQueue extends DocumentUploadQueue {
     }
     documentToPartiallyUpdateList.add(document);
     if (logger.isDebugEnabled()) {
-      logger.info("Adding document to batch: " + document.documentId);
+      logger.debug("Adding document to batch: " + document.documentId);
     }
     this.size += sizeOfDoc;
   }

--- a/src/main/java/com/coveo/pushapiclient/UpdateStreamService.java
+++ b/src/main/java/com/coveo/pushapiclient/UpdateStreamService.java
@@ -218,7 +218,6 @@ public class UpdateStreamService {
   private UploadStrategy getUploadStrategy() {
     return (streamUpdate) -> {
       String batchUpdateJson = new Gson().toJson(streamUpdate.marshal());
-      System.out.println(batchUpdateJson);
       return this.platformClient.uploadContentToFileContainer(fileContainer, batchUpdateJson);
     };
   }


### PR DESCRIPTION
Modified logging level when adding documents to a queue so that when there are large numbers of documents to push, the logs are not filled with all the documents that are added.

Also removed a System.out.println statement.